### PR TITLE
Implement Broadcast Feature

### DIFF
--- a/realtime/events.go
+++ b/realtime/events.go
@@ -64,12 +64,12 @@ type CustomEvent struct {
 // Verify if the given event type is supported
 func verifyEventType(eventType string) bool {
 	switch eventType {
-	case presenceEventType:
-      fallthrough
-	case broadcastEventType:
-      fallthrough
-	case postgresChangesEventType:
-		return true
+      case presenceEventType:
+         fallthrough
+      case broadcastEventType:
+         fallthrough
+      case postgresChangesEventType:
+         return true
 	}
 
 	return false

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -58,7 +58,9 @@ type presenceFilter struct {
 func verifyEventType(eventType string) bool {
 	switch eventType {
 	case presenceEventType:
+      fallthrough
 	case broadcastEventType:
+      fallthrough
 	case postgresChangesEventType:
 		return true
 	}

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -3,6 +3,7 @@ package realtime
 import (
 	"fmt"
 	"reflect"
+	"strings"
 )
 
 // Events that are used to communicate with the server
@@ -16,7 +17,91 @@ const (
    // Broadcast Events
    broadcastEvent string = "broadcast"
 
-// Other Events
-const SYS_EVENT = "system"
-const HEARTBEAT_EVENT = "heartbeat"
-const ACCESS_TOKEN_EVENT = "access_token"
+   // Presence Events
+   presenceStateEvent string = "presence_state"
+   presenceDiffEvent string ="presence_diff"
+
+   // Other Events
+   systemEvent string = "system"
+   heartbeatEvent string = "heartbeat"
+   accessTokennEvent string = "access_token"
+)
+
+// Event "type" that the user can specify for channel to listen to
+const (
+   presenceEventType        string = "presence"
+   broadcastEventType       string = "broadcast"
+   postgresChangesEventType string = "postgres_changes"
+)
+
+type eventFilter interface {
+   verifyFilter(map[string]string)
+}
+
+type postgresFilter struct {
+   Event    string
+   Schema   string
+   Table    string
+   Filter   string
+}
+
+type broadcastFilter struct {
+   event string
+}
+
+type presenceFilter struct {
+   event string
+}
+
+// Verify if the given event type is supported
+func verifyEventType(eventType string) bool {
+   switch eventType {
+      case presenceEventType:
+      case broadcastEventType:
+      case postgresChangesEventType:
+         return true
+   }
+
+   return false
+}
+
+
+// Enforce client's filter object to follow a specific message
+// structure of certain events. Check messages.go for more
+// information on the struct of each event. By default,
+// non-supported events will return an error
+// Only the following events are currently supported:
+//    + postgres_changes, broadcast, presence
+func verifyFilter(eventType string, filter map[string]string) error {
+   var filterType reflect.Type
+   var missingFields []string
+
+   switch eventType {
+      case postgresChangesEvent:
+         filterType = reflect.TypeOf(postgresFilter{})
+         break
+      case broadcastEvent:
+         filterType = reflect.TypeOf(broadcastFilter{})
+         break
+      case presenceEventType:
+         filterType = reflect.TypeOf(presenceFilter{})
+      default:
+         return fmt.Errorf("Unsupported event type: %s", eventType)
+   }
+
+   missingFields = make([]string, 0, filterType.NumField())
+   for i := 0; i < filterType.NumField(); i++ {
+      currFieldName := filterType.Field(i).Name
+      currFieldName  = strings.ToLower(currFieldName)
+
+      if _, ok := filter[currFieldName]; !ok {
+         missingFields = append(missingFields, currFieldName)
+      }
+   }
+
+   if len(missingFields) != 0 {
+      return fmt.Errorf("Criteria for %s is missing: %+v", eventType, missingFields)
+   }
+
+   return nil
+}

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -10,6 +10,8 @@ import (
 const (
 	joinEvent  string = "phx_join"
 	replyEvent string = "phx_reply"
+	leaveEvent string = "phx_leave"
+	closeEvent string = "phx_close"
 
 	// DB Subscription Events
 	postgresChangesEvent string = "postgres_changes"

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -34,23 +34,19 @@ const (
    postgresChangesEventType string = "postgres_changes"
 )
 
-type eventFilter interface {
-   verifyFilter(map[string]string)
-}
-
 type postgresFilter struct {
-   Event    string
-   Schema   string
-   Table    string
-   Filter   string
+   Event    string   `supabase:"required"`
+   Schema   string   `supabase:"required"`
+   Table    string   `supabase:"optional"`
+   Filter   string   `supabase:"optional"`
 }
 
 type broadcastFilter struct {
-   event string
+   event string   `supabase:"required"`
 }
 
 type presenceFilter struct {
-   event string
+   event string   `supabase:"required"`
 }
 
 // Verify if the given event type is supported
@@ -91,10 +87,11 @@ func verifyFilter(eventType string, filter map[string]string) error {
 
    missingFields = make([]string, 0, filterType.NumField())
    for i := 0; i < filterType.NumField(); i++ {
-      currFieldName := filterType.Field(i).Name
-      currFieldName  = strings.ToLower(currFieldName)
+      currField      := filterType.Field(i)
+      currFieldName  := strings.ToLower(currField.Name)
+      isRequired     := currField.Tag.Get("supabase") == "required"
 
-      if _, ok := filter[currFieldName]; !ok {
+      if _, ok := filter[currFieldName]; !ok && isRequired {
          missingFields = append(missingFields, currFieldName)
       }
    }

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -8,127 +8,113 @@ import (
 
 // Events that are used to communicate with the server
 const (
-   joinEvent string = "phx_join"
-   replyEvent string = "phx_reply"
+	joinEvent  string = "phx_join"
+	replyEvent string = "phx_reply"
 
-   // DB Subscription Events
-   postgresChangesEvent string = "postgres_changes"
+	// DB Subscription Events
+	postgresChangesEvent string = "postgres_changes"
 
-   // Broadcast Events
-   broadcastEvent string = "broadcast"
+	// Broadcast Events
+	broadcastEvent string = "broadcast"
 
-   // Presence Events
-   presenceStateEvent string = "presence_state"
-   presenceDiffEvent string ="presence_diff"
+	// Presence Events
+	presenceStateEvent string = "presence_state"
+	presenceDiffEvent  string = "presence_diff"
 
-   // Other Events
-   systemEvent string = "system"
-   heartbeatEvent string = "heartbeat"
-   accessTokennEvent string = "access_token"
+	// Other Events
+	systemEvent       string = "system"
+	heartbeatEvent    string = "heartbeat"
+	accessTokennEvent string = "access_token"
 )
 
 // Event "type" that the user can specify for channel to listen to
 const (
-   presenceEventType        string = "presence"
-   broadcastEventType       string = "broadcast"
-   postgresChangesEventType string = "postgres_changes"
+	presenceEventType        string = "presence"
+	broadcastEventType       string = "broadcast"
+	postgresChangesEventType string = "postgres_changes"
 )
 
-type eventFilter interface {
-   constructPayload() string
-}
+// type eventFilter struct {}
+type eventFilter interface {}
 
 type postgresFilter struct {
-   Event    string   `supabase:"required"`
-   Schema   string   `supabase:"required"`
-   Table    string   `supabase:"optional"`
-   Filter   string   `supabase:"optional"`
+   Event  string `supabase:"required" json:"event"`
+	Schema string `supabase:"required" json:"schema"`
+	Table  string `supabase:"optional" json:"table"`
+	Filter string `supabase:"optional" json:"filter"`
 }
 
 type broadcastFilter struct {
-   event string   `supabase:"required"`
+	Event string `supabase:"required"`
 }
 
 type presenceFilter struct {
-   event string   `supabase:"required"`
-}
-
-func (filter *postgresFilter) constructPayload() string {
-   return ""
-}
-
-func (filter *broadcastFilter) constructPayload() string {
-   return ""
-}
-
-func (filter *presenceFilter) constructPayload() string{
-   return ""
+	Event string `supabase:"required"`
 }
 
 // Verify if the given event type is supported
 func verifyEventType(eventType string) bool {
-   switch eventType {
-      case presenceEventType:
-      case broadcastEventType:
-      case postgresChangesEventType:
-         return true
-   }
+	switch eventType {
+	case presenceEventType:
+	case broadcastEventType:
+	case postgresChangesEventType:
+		return true
+	}
 
-   return false
+	return false
 }
-
 
 // Enforce client's filter object to follow a specific message
 // structure of certain events. Check messages.go for more
 // information on the struct of each event.
 // Only the following events are currently supported:
-//    + postgres_changes, broadcast, presence
-func createFilter(eventType string, filter map[string]string) (eventFilter, error) {
-   var filterType       reflect.Type   // Type for filter
-   var filterConValue   reflect.Value  // Concrete value
-   var filterPtrValue   reflect.Value  // Pointer value to the concrete value
-   var missingFields []string
+//   - postgres_changes, broadcast, presence
+func createEventFilter(eventType string, filter map[string]string) (eventFilter, error) {
+	var filterType reflect.Type      // Type for filter
+	var filterConValue reflect.Value // Concrete value
+	var filterPtrValue reflect.Value // Pointer value to the concrete value
+	var missingFields []string
 
-   switch eventType {
-      case postgresChangesEvent:
-         filterPtrValue = reflect.ValueOf(&postgresFilter{})
-         break
-      case broadcastEvent:
-         filterPtrValue = reflect.ValueOf(&broadcastFilter{})
-         break
-      case presenceEventType:
-         filterPtrValue = reflect.ValueOf(&presenceFilter{})
-      default:
-         return nil, fmt.Errorf("Unsupported event type: %s", eventType)
-   }
+	switch eventType {
+	case postgresChangesEvent:
+		filterPtrValue = reflect.ValueOf(&postgresFilter{})
+		break
+	case broadcastEvent:
+		filterPtrValue = reflect.ValueOf(&broadcastFilter{})
+		break
+	case presenceEventType:
+		filterPtrValue = reflect.ValueOf(&presenceFilter{})
+	default:
+		return nil, fmt.Errorf("Unsupported event type: %s", eventType)
+	}
 
-   // Get the underlying filter type to identify missing fields
-   filterConValue = filterPtrValue.Elem()
-   filterType     = filterConValue.Type()
-   missingFields  = make([]string, 0, filterType.NumField())
+	// Get the underlying filter type to identify missing fields
+	filterConValue = filterPtrValue.Elem()
+	filterType = filterConValue.Type()
+	missingFields = make([]string, 0, filterType.NumField())
 
-   for i := 0; i < filterType.NumField(); i++ {
-      currField      := filterType.Field(i)
-      currFieldName  := strings.ToLower(currField.Name)
-      isRequired     := currField.Tag.Get("supabase") == "required"
+	for i := 0; i < filterType.NumField(); i++ {
+		currField := filterType.Field(i)
+		currFieldName := strings.ToLower(currField.Name)
+		isRequired := currField.Tag.Get("supabase") == "required"
 
-      val, ok        := filter[currFieldName]
-      if !ok && isRequired {
-         missingFields = append(missingFields, currFieldName)
-      }
-      
-      // Set field to empty string when value for currFieldName is missing
-      filterConValue.Field(i).SetString(val)
-   }
+		val, ok := filter[currFieldName]
+		if !ok && isRequired {
+			missingFields = append(missingFields, currFieldName)
+		}
 
-   if len(missingFields) != 0 {
-      return nil, fmt.Errorf("Criteria for %s is missing: %+v", eventType, missingFields)
-   }
+		// Set field to empty string when value for currFieldName is missing
+		filterConValue.Field(i).SetString(val)
+	}
 
-   filterFinal, ok  := filterPtrValue.Interface().(eventFilter)
-   if !ok {
-      return nil, fmt.Errorf("Unexpected Error: cannot create event filter")
-   }
+	if len(missingFields) != 0 {
+		return nil, fmt.Errorf("Criteria for %s is missing: %+v", eventType, missingFields)
+	}
 
-   return filterFinal, nil
+	filterFinal, ok := filterConValue.Interface().(eventFilter)
+	if !ok {
+		return nil, fmt.Errorf("Unexpected Error: cannot create event filter")
+	}
+
+	return filterFinal, nil
 }

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -1,18 +1,20 @@
-package realtime;
+package realtime
 
-// Channel Events
-const JOIN_EVENT = "phx_join"
-const REPLY_EVENT = "phx_reply"
+import (
+	"fmt"
+	"reflect"
+)
 
-// DB Subscription Events
-const POSTGRES_CHANGE_EVENT = "postgres_changes"
+// Events that are used to communicate with the server
+const (
+   joinEvent string = "phx_join"
+   replyEvent string = "phx_reply"
 
-// Broadcast Events
-const BROADCAST_EVENT = "broadcast"
+   // DB Subscription Events
+   postgresChangesEvent string = "postgres_changes"
 
-// Presence Events
-const PRESENCE_STATE_EVENT = "presence_state"
-const PRESENCE_DIFF_EVENT ="presence_diff"
+   // Broadcast Events
+   broadcastEvent string = "broadcast"
 
 // Other Events
 const SYS_EVENT = "system"

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -40,8 +40,8 @@ type eventFilter interface {}
 type postgresFilter struct {
    Event  string `supabase:"required" json:"event"`
 	Schema string `supabase:"required" json:"schema"`
-	Table  string `supabase:"optional" json:"table"`
-	Filter string `supabase:"optional" json:"filter"`
+	Table  string `supabase:"optional" json:"table,omitempty"`
+	Filter string `supabase:"optional" json:"filter,omitempty"`
 }
 
 type broadcastFilter struct {

--- a/realtime/events.go
+++ b/realtime/events.go
@@ -54,6 +54,13 @@ type presenceFilter struct {
 	Event string `supabase:"required"`
 }
 
+// Custom event that can be sent to the server
+type CustomEvent struct {
+   Event    string   `json:"event"`
+   Payload  any      `json:"payload"`
+   Type     string   `json:"type"`
+}
+
 // Verify if the given event type is supported
 func verifyEventType(eventType string) bool {
 	switch eventType {

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -68,13 +68,17 @@ type SystemPayload struct {
 
 type PostgresCDCPayload struct {
    Data struct {
-      Schema     string            `json:"schema"`
-      Table      string            `json:"table"`
-      CommitTime string            `json:"commit_timestamp"`
-      EventType  string            `json:"eventType"`
-      New        map[string]string `json:"new"`
-      Old        map[string]string `json:"old"`
-      Errors     string            `json:"errors"`
+      Schema     string          `json:"schema"`
+      Table      string          `json:"table"`
+      CommitTime string          `json:"commit_timestamp"`
+      Record     map[string]any  `json:"record"`
+      Columns    []struct{
+         Name string `json:"name"`
+         Type string `json:"type"`
+      } `json:"columns"`
+      EventType  string          `json:"type"`
+      Old        map[string]any  `json:"old_record"`
+      Errors     string          `json:"errors"`
    } `json:"data"`
    IDs []int `json:"ids"`
 }

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -1,7 +1,6 @@
 package realtime
 
 import (
-	"container/list"
 	"encoding/json"
 )
 
@@ -110,20 +109,13 @@ func createTemplateMessage(event string, topic string) *TemplateMsg {
 }
 
 // create a connection message depending on event type
-func createConnectionMessage(topic string, bindings *list.List) *ConnectionMsg {
+func createConnectionMessage(topic string, bindings []*binding) *ConnectionMsg {
 	msg := &ConnectionMsg{}
-   bindNode := bindings.Front()
-
    // Fill out the message template
    msg.TemplateMsg = createTemplateMessage(joinEvent, topic)
 
    // Fill out the payload
-   for bindNode != nil {
-      bind, ok := bindNode.Value.(binding)
-      if !ok {
-         panic("TYPE ASSERTION FAILED: expecting type binding")
-      } 
-
+   for _, bind := range bindings {
       filter := bind.filter
       switch filter.(type) {
          case postgresFilter:
@@ -141,8 +133,6 @@ func createConnectionMessage(topic string, bindings *list.List) *ConnectionMsg {
          default:
             panic("TYPE ASSERTION FAILED: expecting one of postgresFilter, broadcastFilter, or presenceFilter")
       }
-
-      bindNode = bindNode.Next()
    }
 
 	return msg

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -48,16 +48,16 @@ type HearbeatMsg struct {
 }
 
 // create a template message
-func createTemplateMessage(event string, topic realtimeTopic) *TemplateMsg {
+func createTemplateMessage(event string, topic string) *TemplateMsg {
    return &TemplateMsg{
       Event: event,
-      Topic: string(topic),
+      Topic: topic,
       Ref: "",
    }
 }
 
 // create a connection message depending on event type
-func createConnectionMessage(topic realtimeTopic, filter eventFilter) *ConnectionMsg {
+func createConnectionMessage(topic string, filter eventFilter) *ConnectionMsg {
    msg := &ConnectionMsg{}
 
    // Common part across the three event type

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -7,7 +7,25 @@ type TemplateMsg struct {
 }
 
 type ConnectionMsg struct {
-   TemplateMsg
+   *TemplateMsg
+
+   Payload struct {
+      Config struct {
+         Broadcast struct {
+            Self bool `json:"self"`
+         } `json:"broadcast"`
+
+         Presence struct {
+            Key string `json:"key"`
+         } `json:"presence"`
+
+         PostgresChanges []postgresFilter `json:"postgres_changes"`
+      } `json:"config"`
+   } `json:"payload"`
+}
+
+type PostgresCDCMsg struct {
+   *TemplateMsg
 
    Payload struct {
       Data struct {
@@ -23,8 +41,38 @@ type ConnectionMsg struct {
 }
 
 type HearbeatMsg struct {
-   TemplateMsg
+   *TemplateMsg
 
    Payload struct {
    } `json:"payload"`
+}
+
+// create a template message
+func createTemplateMessage(event string, topic realtimeTopic) *TemplateMsg {
+   return &TemplateMsg{
+      Event: event,
+      Topic: string(topic),
+      Ref: "",
+   }
+}
+
+// create a connection message depending on event type
+func createConnectionMessage(topic realtimeTopic, filter eventFilter) *ConnectionMsg {
+   msg := &ConnectionMsg{}
+
+   // Common part across the three event type
+   msg.TemplateMsg = createTemplateMessage(joinEvent, topic)
+   switch filter.(type)  {
+   case postgresFilter:
+      msg.Payload.Config.PostgresChanges = []postgresFilter{filter.(postgresFilter)}
+      break
+   case broadcastFilter:
+      msg.Payload.Config.Broadcast.Self = true
+      break
+   case presenceFilter:
+      msg.Payload.Config.Presence.Key = ""
+      break
+   }
+
+   return msg
 }

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -66,6 +66,19 @@ type SystemPayload struct {
    Status      string `json:"status"`
 }
 
+type PostgresCDCPayload struct {
+   Data struct {
+      Schema     string            `json:"schema"`
+      Table      string            `json:"table"`
+      CommitTime string            `json:"commit_timestamp"`
+      EventType  string            `json:"eventType"`
+      New        map[string]string `json:"new"`
+      Old        map[string]string `json:"old"`
+      Errors     string            `json:"errors"`
+   } `json:"data"`
+   IDs []int `json:"ids"`
+}
+
 // presence_state can contain any key. Hence map type instead of struct
 type PresenceStatePayload map[string]struct{
    Metas []struct{

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -4,51 +4,57 @@ import (
 	"encoding/json"
 )
 
-type TemplateMsg struct {
+// This is a general message strucutre. It follows the message protocol 
+// of the phoenix server:
+/*
+   {
+      event: string,
+      topic: string,
+      payload: [key: string]: boolean | int | string | any,
+      ref: string
+   }
+*/
+type Msg struct {
+   Metadata
+   Payload any `json:"payload"`
+}
+
+// Generic message that contains raw payload. It can be used
+// as a tagged union, where the event field can be used to
+// determine the structure of the payload.
+type RawMsg struct {
+	Metadata
+	Payload json.RawMessage `json:"payload"`
+}
+
+// The other fields besides the payload that make up a message.
+// It describes other information about a message such as type of event,
+// the topic the message belongs to, and its reference.
+type Metadata struct {
 	Event string `json:"event"`
 	Topic string `json:"topic"`
 	Ref   string `json:"ref"`
 }
 
-type AbstractMsg struct {
-	*TemplateMsg
-	Payload json.RawMessage `json:"payload"`
+// Payload for the conection message for when client first joins the channel. 
+// More info: https://supabase.com/docs/guides/realtime/protocol#connection
+type ConnectionPayload struct {
+   Config struct {
+      Broadcast struct {
+         Self bool `json:"self"`
+      } `json:"broadcast,omitempty"`
+
+      Presence struct {
+         Key string `json:"key"`
+      } `json:"presence,omitempty"`
+
+      PostgresChanges []postgresFilter `json:"postgres_changes,omitempty"`
+   } `json:"config"`
 }
 
-type ConnectionMsg struct {
-	*TemplateMsg
-
-	Payload struct {
-		Config struct {
-			Broadcast struct {
-				Self bool `json:"self"`
-			} `json:"broadcast,omitempty"`
-
-			Presence struct {
-				Key string `json:"key"`
-			} `json:"presence,omitempty"`
-
-			PostgresChanges []postgresFilter `json:"postgres_changes,omitempty"`
-		} `json:"config"`
-	} `json:"payload"`
-}
-
-type PostgresCDCMsg struct {
-	*TemplateMsg
-
-	Payload struct {
-		Data struct {
-			Schema     string            `json:"schema"`
-			Table      string            `json:"table"`
-			CommitTime string            `json:"commit_timestamp"`
-			EventType  string            `json:"eventType"`
-			New        map[string]string `json:"new"`
-			Old        map[string]string `json:"old"`
-			Errors     string            `json:"errors"`
-		} `json:"data"`
-	} `json:"payload"`
-}
-
+// Payload of the server's first response of three upon joining channel. 
+// It contains details about subscribed postgres events.
+// More info: https://supabase.com/docs/guides/realtime/protocol#connection
 type ReplyPayload struct {
    Response struct {
       PostgresChanges []struct{
@@ -59,6 +65,9 @@ type ReplyPayload struct {
    Status string `json:"status"`
 }
 
+// Payload of the server's second response of three upon joining channel. 
+// It contains details about the status of subscribing to PostgresSQL.
+// More info: https://supabase.com/docs/guides/realtime/protocol#system-messages
 type SystemPayload struct {
    Channel     string `json:"channel"`
    Extension   string `json:"extension"`
@@ -66,6 +75,19 @@ type SystemPayload struct {
    Status      string `json:"status"`
 }
 
+// Payload of the server's third response of three upon joining channel. 
+// It contains details about the Presence feature of Supabase.
+// More info: https://supabase.com/docs/guides/realtime/protocol#state-update
+type PresenceStatePayload map[string]struct{
+   Metas []struct{
+      Ref   string   `json:"phx_ref"` 
+      Name  string   `json:"name"` 
+      T     float64  `json:"t"` 
+   } `json:"metas,omitempty"`
+}
+
+// Payload of the server's response when there is a postgres_changes event. 
+// More info: https://supabase.com/docs/guides/realtime/protocol#system-messages
 type PostgresCDCPayload struct {
    Data struct {
       Schema     string          `json:"schema"`
@@ -83,26 +105,9 @@ type PostgresCDCPayload struct {
    IDs []int `json:"ids"`
 }
 
-// presence_state can contain any key. Hence map type instead of struct
-type PresenceStatePayload map[string]struct{
-   Metas []struct{
-      Ref   string   `json:"phx_ref"` 
-      Name  string   `json:"name"` 
-      T     float64  `json:"t"` 
-   } `json:"metas,omitempty"`
-}
-
-// Messages that have empty payload
-type BlankMsg struct {
-	*TemplateMsg
-
-	Payload struct {
-	} `json:"payload"`
-}
-
 // create a template message
-func createTemplateMessage(event string, topic string) *TemplateMsg {
-	return &TemplateMsg{
+func createMsgMetadata(event string, topic string) *Metadata {
+	return &Metadata{
 		Event: event,
 		Topic: topic,
 		Ref:   "",
@@ -110,31 +115,35 @@ func createTemplateMessage(event string, topic string) *TemplateMsg {
 }
 
 // create a connection message depending on event type
-func createConnectionMessage(topic string, bindings []*binding) *ConnectionMsg {
-	msg := &ConnectionMsg{}
+func createConnectionMessage(topic string, bindings []*binding) *Msg {
+	msg := &Msg{}
+
    // Fill out the message template
-   msg.TemplateMsg = createTemplateMessage(joinEvent, topic)
+   msg.Metadata = *createMsgMetadata(joinEvent, topic)
 
    // Fill out the payload
+   payload := &ConnectionPayload{}
    for _, bind := range bindings {
       filter := bind.filter
       switch filter.(type) {
          case postgresFilter:
-            if msg.Payload.Config.PostgresChanges == nil {
-               msg.Payload.Config.PostgresChanges = make([]postgresFilter, 0, 1)
+            if payload.Config.PostgresChanges == nil {
+               payload.Config.PostgresChanges = make([]postgresFilter, 0, 1)
             }
-            msg.Payload.Config.PostgresChanges = append(msg.Payload.Config.PostgresChanges, filter.(postgresFilter))
+            payload.Config.PostgresChanges = append(payload.Config.PostgresChanges, filter.(postgresFilter))
             break
          case broadcastFilter:
-            msg.Payload.Config.Broadcast.Self = true
+            payload.Config.Broadcast.Self = true
             break
          case presenceFilter:
-            msg.Payload.Config.Presence.Key = ""
+            payload.Config.Presence.Key = ""
             break
          default:
             panic("TYPE ASSERTION FAILED: expecting one of postgresFilter, broadcastFilter, or presenceFilter")
       }
    }
+
+   msg.Payload = payload
 
 	return msg
 }

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -2,9 +2,11 @@ package realtime
 
 import (
 	"encoding/json"
+	"strconv"
+	"time"
 )
 
-// This is a general message strucutre. It follows the message protocol 
+// This is a general message strucutre. It follows the message protocol
 // of the phoenix server:
 /*
    {
@@ -120,6 +122,7 @@ func createConnectionMessage(topic string, bindings []*binding) *Msg {
 
    // Fill out the message template
    msg.Metadata = *createMsgMetadata(joinEvent, topic)
+   msg.Metadata.Ref = strconv.FormatInt(time.Now().Unix(), 10)
 
    // Fill out the payload
    payload := &ConnectionPayload{}

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -112,7 +112,7 @@ type PostgresCDCPayload struct {
 type BroadcastPayload struct {
    Event    string `json:"event"`
    Payload  any    `json:"payload"`
-   Type     string `json:"broadcast"`
+   Type     string `json:"type"`
 }
 
 // create a template message

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -92,7 +92,8 @@ type PresenceStatePayload map[string]struct{
    } `json:"metas,omitempty"`
 }
 
-type HearbeatMsg struct {
+// Messages that have empty payload
+type BlankMsg struct {
 	*TemplateMsg
 
 	Payload struct {

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -105,6 +105,14 @@ type PostgresCDCPayload struct {
    IDs []int `json:"ids"`
 }
 
+// Payload of the server's response when there is a broadcast event. 
+// More info: https://supabase.com/docs/guides/realtime/protocol#broadcast-message
+type BroadcastPayload struct {
+   Event    string `json:"event"`
+   Payload  any    `json:"payload"`
+   Type     string `json:"broadcast"`
+}
+
 // create a template message
 func createMsgMetadata(event string, topic string) *Metadata {
 	return &Metadata{

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -77,7 +77,7 @@ type PostgresCDCPayload struct {
          Name string `json:"name"`
          Type string `json:"type"`
       } `json:"columns"`
-      EventType  string          `json:"type"`
+      ActionType  string          `json:"type"`
       Old        map[string]any  `json:"old_record"`
       Errors     string          `json:"errors"`
    } `json:"data"`

--- a/realtime/messages.go
+++ b/realtime/messages.go
@@ -1,78 +1,112 @@
-package realtime;
+package realtime
+
+import (
+	"encoding/json"
+)
 
 type TemplateMsg struct {
-   Event string `json:"event"`
-   Topic string `json:"topic"`
-   Ref string `json:"ref"`
+	Event string `json:"event"`
+	Topic string `json:"topic"`
+	Ref   string `json:"ref"`
+}
+
+type AbstractMsg struct {
+	*TemplateMsg
+	Payload json.RawMessage `json:"payload"`
 }
 
 type ConnectionMsg struct {
-   *TemplateMsg
+	*TemplateMsg
 
-   Payload struct {
-      Config struct {
-         Broadcast struct {
-            Self bool `json:"self"`
-         } `json:"broadcast"`
+	Payload struct {
+		Config struct {
+			Broadcast struct {
+				Self bool `json:"self"`
+			} `json:"broadcast,omitempty"`
 
-         Presence struct {
-            Key string `json:"key"`
-         } `json:"presence"`
+			Presence struct {
+				Key string `json:"key"`
+			} `json:"presence,omitempty"`
 
-         PostgresChanges []postgresFilter `json:"postgres_changes"`
-      } `json:"config"`
-   } `json:"payload"`
+			PostgresChanges []postgresFilter `json:"postgres_changes,omitempty"`
+		} `json:"config"`
+	} `json:"payload"`
 }
 
 type PostgresCDCMsg struct {
-   *TemplateMsg
+	*TemplateMsg
 
-   Payload struct {
-      Data struct {
-         Schema string `json:"schema"`
-         Table string `json:"table"`
-         CommitTime string `json:"commit_timestamp"`
-         EventType string  `json:"eventType"`
-         New map[string]string `json:"new"`
-         Old map[string]string `json:"old"`
-         Errors string `json:"errors"`
-      } `json:"data"`
-   } `json:"payload"`
+	Payload struct {
+		Data struct {
+			Schema     string            `json:"schema"`
+			Table      string            `json:"table"`
+			CommitTime string            `json:"commit_timestamp"`
+			EventType  string            `json:"eventType"`
+			New        map[string]string `json:"new"`
+			Old        map[string]string `json:"old"`
+			Errors     string            `json:"errors"`
+		} `json:"data"`
+	} `json:"payload"`
+}
+
+type ReplyPayload struct {
+   Response struct {
+      PostgresChanges []struct{
+         ID int `json:"id"`
+         postgresFilter
+      } `json:"postgres_changes"`
+   } `json:"response"`
+   Status string `json:"status"`
+}
+
+type SystemPayload struct {
+   Channel     string `json:"channel"`
+   Extension   string `json:"extension"`
+   Message     string `json:"message"`
+   Status      string `json:"status"`
+}
+
+// presence_state can contain any key. Hence map type instead of struct
+type PresenceStatePayload map[string]struct{
+   Metas []struct{
+      Ref   string   `json:"phx_ref"` 
+      Name  string   `json:"name"` 
+      T     float64  `json:"t"` 
+   } `json:"metas,omitempty"`
 }
 
 type HearbeatMsg struct {
-   *TemplateMsg
+	*TemplateMsg
 
-   Payload struct {
-   } `json:"payload"`
+	Payload struct {
+	} `json:"payload"`
 }
 
 // create a template message
 func createTemplateMessage(event string, topic string) *TemplateMsg {
-   return &TemplateMsg{
-      Event: event,
-      Topic: topic,
-      Ref: "",
-   }
+	return &TemplateMsg{
+		Event: event,
+		Topic: topic,
+		Ref:   "",
+	}
 }
 
 // create a connection message depending on event type
 func createConnectionMessage(topic string, filter eventFilter) *ConnectionMsg {
-   msg := &ConnectionMsg{}
+	msg := &ConnectionMsg{}
 
-   // Common part across the three event type
-   msg.TemplateMsg = createTemplateMessage(joinEvent, topic)
-   switch filter.(type)  {
-   case postgresFilter:
-      msg.Payload.Config.PostgresChanges = []postgresFilter{filter.(postgresFilter)}
-      break
-   case broadcastFilter:
-      msg.Payload.Config.Broadcast.Self = true
-      break
-   case presenceFilter:
-      msg.Payload.Config.Presence.Key = ""
-      break
-   }
-
-   return msg
+	// Common part across the three event type
+	msg.TemplateMsg = createTemplateMessage(joinEvent, topic)
+	switch filter.(type) {
+	case postgresFilter:
+		msg.Payload.Config.PostgresChanges = []postgresFilter{filter.(postgresFilter)}
+		break
+	case broadcastFilter:
+		msg.Payload.Config.Broadcast.Self = true
+		break
+	case presenceFilter:
+		msg.Payload.Config.Presence.Key = ""
+		break
+	}
+	return msg
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -24,12 +24,19 @@ func (channel *RealtimeChannel) On(eventType string, filter map[string]string, c
    if !verifyEventType(eventType) {
       return fmt.Errorf("invalid event type: %s", eventType)
    }
-   eventFilter, err := createFilter(eventType, filter)
+   eventFilter, err := createEventFilter(eventType, filter)
    if err != nil {
       return fmt.Errorf("Invalid filter criteria for %s event type: %w", eventType, err)
    }
 
-   fmt.Println(eventFilter)
+   fmt.Printf("%+v\n", eventFilter)
+   msg := createConnectionMessage(channel.topic, eventFilter)
+   fmt.Printf("%+v\n", msg)
+   // binding{
+   //    msg: msg,
+   //    callback: callback,
+   //    channel: channel,
+   // }
 
    return nil
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -127,7 +127,7 @@ func (channel *RealtimeChannel) Unsubscribe(ctx context.Context) {
 }
 
 // Send a custom event to the server
-func (channel *RealtimeChannel) Send(event CustomEvent) error {
+func (channel *RealtimeChannel) Send(event CustomEvent, ctx context.Context) error {
    if !verifyEventType(event.Type) {
       return fmt.Errorf("Invalid event type: %s", event.Type)
    }
@@ -138,7 +138,7 @@ func (channel *RealtimeChannel) Send(event CustomEvent) error {
       Payload: event,
    }
    msg.Metadata.Ref = strconv.FormatInt(time.Now().Unix(), 10)
-   return channel.client.send(msg)
+   return channel.client.send(msg, ctx)
 }
 
 // Route the id of triggered event to appropriate callback

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -1,0 +1,44 @@
+package realtime
+
+import "fmt"
+
+type realtimeTopic string // internal string type for representing topics
+
+type RealtimeChannel struct {
+	topic     realtimeTopic
+	client    *RealtimeClient
+	hasJoined bool
+}
+
+// Initialize a new channel
+func CreateRealtimeChannel(client *RealtimeClient, topic realtimeTopic) *RealtimeChannel {
+	return &RealtimeChannel{
+		client: client,
+		topic:  topic,
+	}
+}
+
+// Perform callbacks on specific events. Successive calls to On()
+// will result in multiple callbacks acting at the event
+func (channel *RealtimeChannel) On() {
+
+}
+
+// Subscribe to the channel and start listening to events
+func (channel *RealtimeChannel) Subscribe() error {
+	if channel.hasJoined {
+		return fmt.Errorf("The channel has already been subscribed")
+	}
+
+	if channel.client.isClientAlive() {
+
+	}
+
+	return nil
+}
+
+func (channel *RealtimeChannel) Unsubscribe() {
+	if channel.client.isClientAlive() {
+
+	}
+}

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -73,8 +73,10 @@ func (channel *RealtimeChannel) Subscribe(ctx context.Context) error {
 
    // Flatten all type of bindings into one slice
    allBindings := make([]*binding, channel.numBindings)
+   startIdx    := 0
    for _, eventType := range []string{postgresChangesEventType, broadcastEventType, presenceEventType} {
-      copy(allBindings, channel.bindings[eventType])
+      copy(allBindings[startIdx:], channel.bindings[eventType])
+      startIdx += len(channel.bindings)
    }
 
    respPayload, err := channel.client.subscribe(channel.topic, allBindings, ctx)

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -27,28 +27,22 @@ func (channel *RealtimeChannel) On(eventType string, filter map[string]string, c
       return fmt.Errorf("Invalid filter criteria for %s event type: %w", eventType, err)
    }
 
-   fmt.Printf("%+v\n", eventFilter)
    msg := createConnectionMessage(channel.topic, eventFilter)
-   fmt.Printf("%+v\n", msg)
    newBinding := binding{
       msg: msg,
       callback: callback,
    }
 
-   channel.client.addBinding(channel.topic, newBinding)
+   channel.client.addBinding(newBinding)
 
    return nil
 }
 
 // Subscribe to the channel and start listening to events
 func (channel *RealtimeChannel) Subscribe() error {
-	if channel.hasJoined {
-		return fmt.Errorf("The channel has already been subscribed")
-	}
-
-	if channel.client.isClientAlive() {
-
-	}
+   if err := channel.client.subscribe(); err != nil {
+      return fmt.Errorf("Channel %s failed to subscribe: %w", channel.topic, err)
+   }
 
 	return nil
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -2,16 +2,14 @@ package realtime
 
 import "fmt"
 
-type realtimeTopic string // internal string type for representing topics
-
 type RealtimeChannel struct {
-	topic     realtimeTopic
+	topic     string
 	client    *RealtimeClient
 	hasJoined bool
 }
 
 // Initialize a new channel
-func CreateRealtimeChannel(client *RealtimeClient, topic realtimeTopic) *RealtimeChannel {
+func CreateRealtimeChannel(client *RealtimeClient, topic string) *RealtimeChannel {
 	return &RealtimeChannel{
 		client: client,
 		topic:  topic,
@@ -20,7 +18,7 @@ func CreateRealtimeChannel(client *RealtimeClient, topic realtimeTopic) *Realtim
 
 // Perform callbacks on specific events. Successive calls to On()
 // will result in multiple callbacks acting at the event
-func (channel *RealtimeChannel) On(eventType string, filter map[string]string, callback func(interface{})) error {
+func (channel *RealtimeChannel) On(eventType string, filter map[string]string, callback func(any)) error {
    if !verifyEventType(eventType) {
       return fmt.Errorf("invalid event type: %s", eventType)
    }
@@ -32,11 +30,12 @@ func (channel *RealtimeChannel) On(eventType string, filter map[string]string, c
    fmt.Printf("%+v\n", eventFilter)
    msg := createConnectionMessage(channel.topic, eventFilter)
    fmt.Printf("%+v\n", msg)
-   // binding{
-   //    msg: msg,
-   //    callback: callback,
-   //    channel: channel,
-   // }
+   newBinding := binding{
+      msg: msg,
+      callback: callback,
+   }
+
+   channel.client.addBinding(channel.topic, newBinding)
 
    return nil
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -17,6 +17,13 @@ type RealtimeChannel struct {
    postgresBindingRoute    map[int]*binding
 }
 
+// Bind an event with the user's callback function
+type binding struct {
+   eventType   string
+   filter      eventFilter
+   callback    func(any)
+}
+
 // Initialize a new channel
 func CreateRealtimeChannel(client *RealtimeClient, topic string) *RealtimeChannel {
 	return &RealtimeChannel{

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"strconv"
+	"time"
 )
 
 type RealtimeChannel struct {
@@ -122,6 +124,21 @@ func (channel *RealtimeChannel) Unsubscribe(ctx context.Context) {
 
    channel.client.unsubscribe(channel.topic, ctx)
    channel.hasSubscribed = false
+}
+
+// Send a custom event to the server
+func (channel *RealtimeChannel) Send(event CustomEvent) error {
+   if !verifyEventType(event.Type) {
+      return fmt.Errorf("Invalid event type: %s", event.Type)
+   }
+
+   metadata := createMsgMetadata(event.Type, channel.topic)
+   msg := &Msg{
+      Metadata: *metadata,
+      Payload: event,
+   }
+   msg.Metadata.Ref = strconv.FormatInt(time.Now().Unix(), 10)
+   return channel.client.send(msg)
 }
 
 // Route the id of triggered event to appropriate callback

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -1,11 +1,18 @@
 package realtime
 
-import "fmt"
+import (
+	"container/list"
+	"context"
+	"fmt"
+)
 
 type RealtimeChannel struct {
 	topic     string
 	client    *RealtimeClient
-	hasJoined bool
+
+   bindings       *list.List 
+   bindingsMap    map[int]binding
+	hasSubscribed  bool
 }
 
 // Initialize a new channel
@@ -13,6 +20,9 @@ func CreateRealtimeChannel(client *RealtimeClient, topic string) *RealtimeChanne
 	return &RealtimeChannel{
 		client: client,
 		topic:  topic,
+      bindings: list.New(),
+      bindingsMap: make(map[int]binding),
+      hasSubscribed: false,
 	}
 }
 
@@ -22,27 +32,58 @@ func (channel *RealtimeChannel) On(eventType string, filter map[string]string, c
    if !verifyEventType(eventType) {
       return fmt.Errorf("invalid event type: %s", eventType)
    }
+
    eventFilter, err := createEventFilter(eventType, filter)
    if err != nil {
       return fmt.Errorf("Invalid filter criteria for %s event type: %w", eventType, err)
    }
 
-   msg := createConnectionMessage(channel.topic, eventFilter)
    newBinding := binding{
-      msg: msg,
+      eventType: eventType,
+      filter: eventFilter,
       callback: callback,
    }
-
-   channel.client.addBinding(newBinding)
+   channel.bindings.PushBack(newBinding)
 
    return nil
 }
 
 // Subscribe to the channel and start listening to events
-func (channel *RealtimeChannel) Subscribe() error {
-   if err := channel.client.subscribe(); err != nil {
-      return fmt.Errorf("Channel %s failed to subscribe: %w", channel.topic, err)
+func (channel *RealtimeChannel) Subscribe(ctx context.Context) error {
+   if channel.hasSubscribed {
+      return fmt.Errorf("Error: Channel %s can only be subscribed once", channel.topic)
    }
+
+   // Do nothing if there are no bindings
+   if channel.bindings.Len() == 0 {
+      return nil
+   }
+
+   ids, err := channel.client.subscribe(channel.topic, channel.bindings, ctx)
+   if err != nil {
+      return fmt.Errorf("Channel %s failed to subscribe: %v", channel.topic, err)
+   }
+   
+   bindNode := channel.bindings.Front()
+   for _, id := range ids {
+      if bindNode == nil {
+         channel.Unsubscribe()
+         return fmt.Errorf("Error: the number subscribed events are not equal to the total events")
+      }
+
+      binding, ok := bindNode.Value.(binding)
+      if !ok {
+         panic("TYPE ASSERTION FAILED: expecting type binding")
+      }
+
+      if binding.eventType == postgresChangesEvent {
+         channel.bindingsMap[id] = binding;
+      }
+
+      bindNode = bindNode.Next()
+   }
+
+   channel.hasSubscribed = true
 
 	return nil
 }
@@ -51,4 +92,15 @@ func (channel *RealtimeChannel) Unsubscribe() {
 	if channel.client.isClientAlive() {
 
 	}
+   channel.hasSubscribed = false
+}
+
+// Route the id of triggered event to appropriate callback
+func (channel *RealtimeChannel) routePostgresEvent(id int, payload *PostgresCDCPayload) {
+   binding, ok := channel.bindingsMap[id] 
+   if !ok {
+      channel.client.logger.Printf("Error: Unrecognized id %v", id)
+   }
+
+   go binding.callback(payload)
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -3,6 +3,7 @@ package realtime
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 )
 
@@ -39,6 +40,7 @@ func CreateRealtimeChannel(client *RealtimeClient, topic string) *RealtimeChanne
 // Perform callbacks on specific events. Successive calls to On()
 // will result in multiple callbacks acting at the event
 func (channel *RealtimeChannel) On(eventType string, filter map[string]string, callback func(any)) error {
+   eventType = strings.ToLower(eventType)
    if !verifyEventType(eventType) {
       return fmt.Errorf("invalid event type: %s", eventType)
    }
@@ -98,8 +100,10 @@ func (channel *RealtimeChannel) Subscribe(ctx context.Context) error {
       if !ok {
          panic("TYPE ASSERTION FAILED: expecting type postgresFilter")
       }
-      if change.Schema != bindingFilter.Schema || change.Event  != bindingFilter.Event ||
-         change.Table  != bindingFilter.Table  || change.Filter != bindingFilter.Filter {
+      if strings.ToLower(change.Schema) != strings.ToLower(bindingFilter.Schema) || 
+         strings.ToUpper(change.Event)  != strings.ToUpper(bindingFilter.Event)  ||
+         strings.ToLower(change.Table)  != strings.ToLower(bindingFilter.Table)  || 
+         strings.ToLower(change.Filter) != strings.ToLower(bindingFilter.Filter) {
          channel.Unsubscribe(ctx)
          return fmt.Errorf("Configuration mismatch between server's event and channel's event")
       }
@@ -143,7 +147,7 @@ func (channel *RealtimeChannel) routePostgresEvent(id int, payload *PostgresCDCP
    }
 
    // Match * | INSERT | UPDATE | DELETE
-   switch bindFilter.Event {
+   switch strings.ToUpper(bindFilter.Event) {
       case "*":
          fallthrough
       case payload.Data.ActionType:

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -24,10 +24,12 @@ func (channel *RealtimeChannel) On(eventType string, filter map[string]string, c
    if !verifyEventType(eventType) {
       return fmt.Errorf("invalid event type: %s", eventType)
    }
-
-   if err := verifyFilter(eventType, filter); err != nil {
+   eventFilter, err := createFilter(eventType, filter)
+   if err != nil {
       return fmt.Errorf("Invalid filter criteria for %s event type: %w", eventType, err)
    }
+
+   fmt.Println(eventFilter)
 
    return nil
 }

--- a/realtime/realtime_channel.go
+++ b/realtime/realtime_channel.go
@@ -20,8 +20,16 @@ func CreateRealtimeChannel(client *RealtimeClient, topic realtimeTopic) *Realtim
 
 // Perform callbacks on specific events. Successive calls to On()
 // will result in multiple callbacks acting at the event
-func (channel *RealtimeChannel) On() {
+func (channel *RealtimeChannel) On(eventType string, filter map[string]string, callback func(interface{})) error {
+   if !verifyEventType(eventType) {
+      return fmt.Errorf("invalid event type: %s", eventType)
+   }
 
+   if err := verifyFilter(eventType, filter); err != nil {
+      return fmt.Errorf("Invalid filter criteria for %s event type: %w", eventType, err)
+   }
+
+   return nil
 }
 
 // Subscribe to the channel and start listening to events

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -1,6 +1,7 @@
 package realtime
 
 import (
+	"container/list"
 	"context"
 	"errors"
 	"fmt"
@@ -26,7 +27,15 @@ type RealtimeClient struct {
    heartbeatDuration time.Duration
    heartbeatInterval time.Duration
 
+   msgQueue          *list.List
+
    topics            map[realtimeTopic]*RealtimeChannel
+}
+
+type binding struct {
+   msg      *ConnectionMsg
+   callback func(interface{})
+   channel  *RealtimeChannel
 }
 
 // Create a new RealtimeClient with user's speicfications
@@ -135,7 +144,7 @@ func (client *RealtimeClient) startHeartbeats() {
 // Send the heartbeat to the realtime server
 func (client *RealtimeClient) sendHeartbeat() error {
    msg := HearbeatMsg{
-      TemplateMsg: TemplateMsg{
+      TemplateMsg: &TemplateMsg{
          Event: heartbeatEvent,
          Topic: "phoenix",
          Ref: "",

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -141,7 +141,7 @@ func (client *RealtimeClient) unsubscribe(topic string, ctx context.Context) {
 }
 
 // Send an event to the server
-func (client *RealtimeClient) send(msg *Msg) error {
+func (client *RealtimeClient) send(msg *Msg, ctx context.Context) error {
    var err error
    if !client.isClientAlive() {
       err = client.Connect()
@@ -151,7 +151,7 @@ func (client *RealtimeClient) send(msg *Msg) error {
       return err
    } 
 
-   err = wsjson.Write(context.Background(), client.conn, msg)
+   err = wsjson.Write(ctx, client.conn, msg)
    if err != nil {
       return fmt.Errorf("Unable to send the connection message: %v", err)
    }

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -31,12 +31,6 @@ type RealtimeClient struct {
    currentTopics        map[string]*RealtimeChannel
 }
 
-type binding struct {
-   eventType  string
-   filter      eventFilter
-   callback func(any)
-}
-
 // Create a new RealtimeClient with user's speicfications
 func CreateRealtimeClient(projectRef string, apiKey string) *RealtimeClient {
    realtimeUrl := fmt.Sprintf(

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -259,6 +259,7 @@ func (client *RealtimeClient) processMessage(msg AbstractMsg) {
          }
          break
       case *PostgresCDCPayload:
+         client.logger.Printf("Processing: %+v", string(msg.Payload))
          if len(payload.IDs) == 0 {
             client.logger.Print("Unexected error: CDC message doesn't have any ids")
          }

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -33,7 +33,7 @@ type RealtimeClient struct {
 }
 
 type binding struct {
-   eventType   string
+   eventType  string
    filter      eventFilter
    callback func(any)
 }

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -25,6 +25,8 @@ type RealtimeClient struct {
    reconnectInterval time.Duration
    heartbeatDuration time.Duration
    heartbeatInterval time.Duration
+
+   topics            map[realtimeTopic]*RealtimeChannel
 }
 
 // Create a new RealtimeClient with user's speicfications
@@ -44,6 +46,7 @@ func CreateRealtimeClient(projectRef string, apiKey string) *RealtimeClient {
       heartbeatDuration: 5   * time.Second,
       heartbeatInterval: 20  * time.Second,
       reconnectInterval: 500 * time.Millisecond,
+      topics: make(map[realtimeTopic]*RealtimeChannel),
    }
 }
 
@@ -91,6 +94,15 @@ func (client *RealtimeClient) Disconnect() error {
    }
    
    return nil
+}
+
+// Create a new channel with given topic string
+func (client *RealtimeClient) Channel(topicStr string) *RealtimeChannel {
+   newTopic    := realtimeTopic(topicStr)
+   newChannel  := CreateRealtimeChannel(client, newTopic)
+   client.topics[newTopic] = newChannel
+
+   return newChannel
 }
 
 // Start sending heartbeats to the server to maintain connection

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -262,6 +262,13 @@ func (client *RealtimeClient) processMessage(msg RawMsg) {
             targetedChannel.routePostgresEvent(id, payload)
          }
          break
+      case *BroadcastPayload:
+         targetedChannel, ok := client.currentTopics[msg.Topic]
+         if !ok {
+            client.logger.Printf("Error: Unrecognized topic %v", msg.Topic)
+         }
+         targetedChannel.routeBroadcastEvent(payload)
+         break
    }
 }
 
@@ -284,6 +291,9 @@ func (client *RealtimeClient) unmarshalPayload(msg RawMsg) (any, error) {
          break
       case presenceStateEvent:
          payload = new(PresenceStatePayload)
+         break
+      case broadcastEvent:
+         payload = new(BroadcastPayload)
          break
       default:
          return struct{}{}, fmt.Errorf("Error: Unsupported event %v", msg.Event)

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -136,7 +136,7 @@ func (client *RealtimeClient) startHeartbeats() {
 func (client *RealtimeClient) sendHeartbeat() error {
    msg := HearbeatMsg{
       TemplateMsg: TemplateMsg{
-         Event: HEARTBEAT_EVENT,
+         Event: heartbeatEvent,
          Topic: "phoenix",
          Ref: "",
       },

--- a/realtime/realtime_client.go
+++ b/realtime/realtime_client.go
@@ -140,6 +140,25 @@ func (client *RealtimeClient) unsubscribe(topic string, ctx context.Context) {
    }
 }
 
+// Send an event to the server
+func (client *RealtimeClient) send(msg *Msg) error {
+   var err error
+   if !client.isClientAlive() {
+      err = client.Connect()
+   }
+
+   if err != nil {
+      return err
+   } 
+
+   err = wsjson.Write(context.Background(), client.conn, msg)
+   if err != nil {
+      return fmt.Errorf("Unable to send the connection message: %v", err)
+   }
+
+   return nil
+}
+
 // Create a new channel with given topic string
 func (client *RealtimeClient) Channel(newTopic string) (*RealtimeChannel, error) {
    if _, ok := client.currentTopics[newTopic]; ok {


### PR DESCRIPTION
## What kind of change does this PR introduce?

As part 2 of many PRs for https://github.com/supabase-community/realtime-go/issues/2, this PR implements broadcast functionalities. It should be merged and reviewed **AFTER** https://github.com/supabase-community/realtime-go/pull/4. More specifically: 
- `RealtimeChannel.Send()` - a new function to send a broadcast message to the server. It takes in a `CustomEvent` struct.
- `RealtimeChannel.Subscribe()` - can now listen to new broadcasted events

## What is the current behavior?
Client could only listen to `postgres_changes` right now, without being able to send any message to the server.

## What is the new behavior?
Client could listen to `broadcast` events as well as send events to the server which will then be broadcasted to all listening clients.

## Additional context
This is a simple echo client & server. There are two clients and two servers. As seen in the videos, messages sent from any client will be picked up by any server.
[![Demo](https://github.com/supabase-community/realtime-go/assets/62190721/9ab82b07-6ac6-4a6a-81c4-792e906081d5)](https://www.youtube.com/watch?v=a1d93iwT7Kg)
